### PR TITLE
Fix slice name bug

### DIFF
--- a/src/reduxtkt/view/viewSlice.tsx
+++ b/src/reduxtkt/view/viewSlice.tsx
@@ -10,7 +10,7 @@ const initialState: viewState = {
 };
 
 export const viewSlice = createSlice({
-  name: "counter",
+  name: "view",
   initialState,
   reducers: {
     changeView: (state, action: PayloadAction<string>) => {


### PR DESCRIPTION
## Summary
- correct `viewSlice` name for Redux reducer

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460dbb2e2c83339488e0bb8af46dbd